### PR TITLE
Enable Dependabot to keep actions updated, down grade gh-pages publish action because new version can't be found

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,11 @@
+# Basic dependabot.yml file with
+# minimum configuration for GitHub Actions
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the
+    # default location of `.github/workflows`
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -230,7 +230,7 @@ jobs:
           name: build-WebGL
           path: build/WebGL
       - name: Deploy to GitHub Pages 🚀
-        uses: JamesIves/github-pages-deploy-action@4.3.3
+        uses: JamesIves/github-pages-deploy-action@4.1.3
         with:
           branch: gh-pages # The branch the action should deploy to.
           folder: build/WebGL # The folder the action should deploy.


### PR DESCRIPTION
Enable Dependabot to keep actions updated, down grade gh-pages publish action because new version can't be found