### PR TITLE
Bug Fix: Enemies can destroy their own shields

### DIFF
--- a/Assets/Scripts/Game/Enemy.cs
+++ b/Assets/Scripts/Game/Enemy.cs
@@ -118,6 +118,11 @@ public abstract class Enemy : MonoBehaviour
     {
         if (_shieldsActive)
         {
+            if (!other.CompareTag("Player") && !other.CompareTag("Laser"))
+            {
+                return;
+            }
+            
             if (other.CompareTag("Laser"))
             {
                 Laser laser = other.GetComponent<Laser>();
@@ -126,6 +131,12 @@ public abstract class Enemy : MonoBehaviour
                     return;
                 }
             }
+
+            if (other.CompareTag("Player"))
+            {
+                if (_player != null) { _player.Damage(); }
+            }
+
             _shieldStrength--;
             _shieldsActive = _shieldStrength > 0;
             if (_shieldVisualizer != null) { _shieldVisualizer.SetActive(_shieldsActive); }


### PR DESCRIPTION
Checked for Player and laser and return immediately if neither is valid for damage to shields. This means powerups wont remove enemy shields either.